### PR TITLE
Update Akaunting_vhost

### DIFF
--- a/vps-related/Akaunting_vhost
+++ b/vps-related/Akaunting_vhost
@@ -40,7 +40,7 @@ server {
   }
 
   # Prevent Direct Access To modules/vendor Folders Except Assets
-  location ~ ^/(modules|vendor)\/(.*)\.((?!ico|gif|jpg|jpeg|png|js\b|css|less|sass|font|woff|woff2|eot|ttf|svg|xls|xlsx).)*$ {
+  location ~ ^/(modules|vendor)\/(.*)\.(?!(ico|gif|jpg|jpeg|png|js|css|less|sass|font|woff|woff2|eot|ttf|svg|xls|xlsx)$).* {
     deny all;
   }
 


### PR DESCRIPTION
What's the problem?

CloudPanel has been updated and command:
```
/usr/bin/clpctl vhost-template:add --name=Akaunting --file=https://github.com/hostinger/packages/raw/master/vps-related/Akaunting_vhost
```
Started to escape `js\b` -- resulting in cannot login to Akaunting template and invalid nginx config

Solution:
Use a cleaner negative lookahead with exact matching

Related: https://hostingers.atlassian.net/browse/GLB-213030